### PR TITLE
fixed crash on Android caused by iPhone styling

### DIFF
--- a/app/styles/index.tss
+++ b/app/styles/index.tss
@@ -1,13 +1,13 @@
 ".window" :{
 	backgroundColor: '#fff',
-	barColor: '#50afe6',
-	statusBarStyle: Titanium.UI.iPhone.StatusBar.LIGHT_CONTENT
+	barColor: '#50afe6'
 },
 
 ".window[platform=ios]": {
 	titleAttributes: {
         color:'white'
-    }
+    },
+	statusBarStyle: Titanium.UI.iPhone.StatusBar.LIGHT_CONTENT
 },
 
 "#tabs":{


### PR DESCRIPTION
This property is only available for iPhone and iPad targets as stated
here :
http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.UI.Window-property-statusBarStyle

The fix is only to move arroud the iPhone specific styling to a styling
rule using plateforme=ios selector.

Not tested on ios, but it should be ok :)
Thanks for the workshop !
